### PR TITLE
Read/Write configuration variable via package spf13/viper .

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -11,6 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/cont
 # Copy the controller-manager into a thin image
 FROM alpine:latest
 WORKDIR /root/
+COPY --from=builder /go/src/github.com/containers-ai/alameda/operator/etc/operator.yml /etc/alameda/operator/operator.yml
 COPY --from=builder /go/src/github.com/containers-ai/alameda/operator/manager .
 EXPOSE 50050/tcp
 ENTRYPOINT ["./manager"]

--- a/operator/etc/operator.yml
+++ b/operator/etc/operator.yml
@@ -1,0 +1,9 @@
+gRPC:
+  bind-address: ":50050"
+  prometheus:
+    host: "prometheus-k8s.openshift-monitoring"
+    port: "9091"
+    protocol: "https"
+    tls-config:
+      insecure-skip-verify: true
+    bearer-token-file: "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/operator/pkg/kubernetes/metrics/prometheus/config.go
+++ b/operator/pkg/kubernetes/metrics/prometheus/config.go
@@ -1,16 +1,12 @@
 package prometheus
 
-import (
-	grpcutils "github.com/containers-ai/alameda/operator/pkg/utils/grpc"
-)
-
 type Config struct {
-	Host      string
-	Port      string
-	Protocol  string
-	TLSConfig *TLSConfig
+	Host            string     `mapstructure:"host"`
+	Port            string     `mapstructure:"port"`
+	Protocol        string     `mapstructure:"protocol"`
+	BearerTokenFile string     `mapstructure:"bearer-token-file"`
+	TLSConfig       *TLSConfig `mapstructure:"tls-config"`
 	// Path to bearer token file.
-	BearerTokenFile string
 
 	bearerToken string
 }
@@ -21,7 +17,7 @@ type TLSConfig struct {
 	// Certificate and key files for client cert authentication to the server.
 	// CertFile           string
 	// KeyFile            string
-	InsecureSkipVerify bool
+	InsecureSkipVerify bool `mapstructure:"insecure-skip-verify"`
 }
 
 func NewConfig() Config {
@@ -38,5 +34,4 @@ func (c *Config) init() {
 	c.TLSConfig = &TLSConfig{
 		InsecureSkipVerify: true,
 	}
-	c.BearerTokenFile = grpcutils.GetPrometheusBearerTokenFile()
 }

--- a/operator/pkg/kubernetes/metrics/prometheus/prometheus.go
+++ b/operator/pkg/kubernetes/metrics/prometheus/prometheus.go
@@ -50,7 +50,7 @@ func New(config Config) (metrics.MetricsDB, error) {
 
 	p.config = config
 
-	if p.config.TLSConfig != nil {
+	if strings.ToLower(p.config.Protocol) == "https" {
 		p.client = http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: p.config.TLSConfig.InsecureSkipVerify},

--- a/operator/pkg/utils/grpc/grpc.go
+++ b/operator/pkg/utils/grpc/grpc.go
@@ -11,7 +11,3 @@ func GetAIServiceAddress() string {
 func GetServerPort() int {
 	return flag.Lookup("server-port").Value.(flag.Getter).Get().(int)
 }
-
-func GetPrometheusBearerTokenFile() string {
-	return flag.Lookup("prometheus-bearer-token-file").Value.(flag.Getter).Get().(string)
-}

--- a/operator/server/config.go
+++ b/operator/server/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Config struct {
-	GRPC    *grpc.Config
+	GRPC    *grpc.Config `mapstructure:"gRPC"`
 	Manager manager.Manager
 }
 

--- a/operator/services/grpc/config.go
+++ b/operator/services/grpc/config.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Config struct {
-	BindAddress string
-	Prometheus  *prometheus.Config
+	BindAddress string             `mapstructure:"bind-address"`
+	Prometheus  *prometheus.Config `mapstructure:"prometheus"`
 }
 
 func NewConfig() *Config {


### PR DESCRIPTION
Signed-off-by: bob.huang <bob.huang@prophetstor.com>

<!-- Please take a look at our [Contributing](https://github.com/containers-ai/alameda/blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to Alameda! -->

**Description of your changes:**
Adding logic to read configuration file from flag "--config" or default file path "/etc/alameda/operator/operator.yml" and from environment variables with prefix "ALAMEDA_OPERATOR_" via package viper.
**Which issue is resolved by this Pull Request:**
Resolves #78 

<!--  **Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) -->
